### PR TITLE
Fix a case sensitivity issue for cross-platform compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
               .target(name: "TwilioCommonLib"),
               .target(name: "TwilioStateMachine") 
           ],
-          path: "Dummy"
+          path: "dummy"
         ),
         .binaryTarget(
             name: "TwilioTwilsockLib",


### PR DESCRIPTION
Package.swift references path Dummy but the actual directory is dummy. It causes build error on case sensitve platform.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
